### PR TITLE
Update speaker agent for ADK v1.x+ compatibility & resolve asyncio error

### DIFF
--- a/agents/speaker/agent.py
+++ b/agents/speaker/agent.py
@@ -1,48 +1,37 @@
-import asyncio
 import os
 from dotenv import load_dotenv
-from google.adk.agents import Agent
+from google.adk.agents import Agent 
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
-from google.adk.models.lite_llm import LiteLlm
+from google.adk.models.lite_llm import LiteLlm 
 
-# Load environment variables from the project root .env file
+
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
 
-async def create_agent():
-    """Creates the TTS Speaker agent by connecting to the ElevenLabs MCP server via uvx."""
-    print("--- Attempting to start and connect to elevenlabs-mcp via uvx ---")
-    
-    tools, exit_stack = await MCPToolset.from_server(
-        connection_params=StdioServerParameters(
-            command='uvx',
-            args=['elevenlabs-mcp'],
-            env={'ELEVENLABS_API_KEY': os.environ.get('ELEVENLABS_API_KEY', '')}
+
+llm_instance = LiteLlm(
+    model="gemini/gemini-2.0-flash", 
+    api_key=os.environ.get("GOOGLE_API_KEY")
+)
+
+root_agent = Agent( 
+    name="tts_speaker_agent",
+    description="Converts provided text into speech using ElevenLabs TTS MCP.",
+    instruction=(
+        "You are a Text-to-Speech agent. Take the text provided by the user or coordinator and "
+        "use the available ElevenLabs TTS tool to convert it into audio. "
+        "When calling the text_to_speech tool, set the parameter 'voice_name' to 'Will'. "
+        "Return the result from the tool (expected to be a URL)."
+    ),
+    model=llm_instance,
+    tools=[
+        MCPToolset( 
+            connection_params=StdioServerParameters(
+                command='uvx',
+                args=['elevenlabs-mcp'],
+                env={'ELEVENLABS_API_KEY': os.environ.get('ELEVENLABS_API_KEY', '')}
+            ),
         )
-    )
+    ],
+)
 
-    print(f"--- Connected to elevenlabs-mcp. Discovered {len(tools)} tool(s). ---")
-    for tool in tools:
-        print(f"  - Discovered tool: {tool.name}")
-
-    # Define LLM for wrapping the tool output if needed
-    llm = LiteLlm(model="gemini/gemini-1.5-flash-latest", api_key=os.environ.get("GOOGLE_API_KEY"))
-
-    # Create the TTS Speaker agent
-    agent_instance = Agent(
-        name="tts_speaker_agent",
-        description="Converts provided text into speech using ElevenLabs TTS MCP.",
-        instruction=(
-            "You are a Text-to-Speech agent. Take the text provided by the user or coordinator and "
-            "use the available ElevenLabs TTS tool to convert it into audio. "
-            "When calling the text_to_speech tool, set the parameter 'voice_name' to 'Will'. "
-            "Return the result from the tool (expected to be a URL)."
-        ),
-        model=llm,
-        tools=tools,
-    )
-
-    return agent_instance, exit_stack
-
-root_agent = create_agent()
-
-    
+print(f"INFO (agent.py): tts_speaker_agent (root_agent) defined synchronously.")


### PR DESCRIPTION
## Update Speaker Agent for Google ADK v1.x+ Compatibility and Windows Stability

**Summary:**

This PR refactors the `tts_speaker_agent` to resolve a `NotImplementedError` on Windows and to align its structure with the recommended patterns for **Google ADK version 1.0 and above**. The previous agent definition, using an `async def create_agent()` factory and `await MCPToolset.from_server(...)`, was based on patterns common in ADK v0.3.0 but led to issues with `asyncio` subprocess creation when used with `adk web` (especially in its default hot-reloading mode) in newer ADK versions on Windows.

**Problem Context (ADK v0.3.0 pattern on newer ADK/Windows):**

*   The `async` initialization of `MCPToolset` in ADK v0.3.0 style code can trigger a `NotImplementedError` from `asyncio._make_subprocess_transport` on Windows when running under `adk web`.
*   This error arises because the `asyncio` event loop policy may not be consistently set to `ProactorEventLoop` (required for async subprocesses on Windows) early enough, particularly with Uvicorn's hot-reloading enabled.
*   A known workaround for this specific issue (when using the older async pattern) is to run `adk web --no-reload`.

**Changes Made (Aligning with ADK v1.x+ Patterns):**

This PR updates the agent to use synchronous `MCPToolset` instantiation, which is the prevalent pattern in Google ADK v1.x+ examples:

1.  **Removed `async def create_agent()`:** The agent is no longer defined via an asynchronous factory function.
2.  **Direct `root_agent` Definition:** `root_agent` is now instantiated directly at the module level.
3.  **Synchronous `MCPToolset` Instantiation:** `MCPToolset` is created synchronously within the agent's `tools` list: `MCPToolset(connection_params=StdioServerParameters(...))`.

**Benefits:**

1.  **Google ADK v1.x+ Compatibility:** The agent structure now aligns with current best practices and examples for ADK version 1.0 and higher.
2.  **Resolves Windows `NotImplementedError`:** Enables the speaker agent to function correctly with `adk web` in its default mode (with hot-reloading) on Windows, without requiring the `--no-reload` flag. The synchronous toolset instantiation appears to manage subprocess creation compatibly with the `adk web` environment.
3.  **Simplified Agent Definition:** Offers a more direct module-level agent definition.

**Migration from ADK v0.3.0 Style:**

This change addresses issues encountered when using an ADK v0.3.0 style agent (with `async def create_agent` and `await MCPToolset.from_server`) in a Google ADK v1.x+ environment, particularly concerning `asyncio` subprocess management on Windows.

**How to Test (with Google ADK v1.x+):**

1.  Ensure your environment is using Google ADK v1.0 or a later version.
2.  Set up `uvx` and `elevenlabs-mcp`.
3.  Ensure `ELEVENLABS_API_KEY` and `GOOGLE_API_KEY` are in the `.env` file.
4.  Run the agent using `adk web` (without the `--no-reload` flag).
5.  Verify the speaker agent loads without errors and the ElevenLabs TTS tool functions correctly.

**Note on `adk web --no-reload`:**
While this PR aims to make the agent robust for the default `adk web` mode in ADK v1.x+, developers still using older ADK versions or facing similar `_make_subprocess_transport NotImplementedError` issues with *asynchronously* initialized MCP tools might find `adk web --no-reload` a useful workaround.